### PR TITLE
Select the correct function when at the end of the function.

### DIFF
--- a/after/ftplugin/c/textobj-function.vim
+++ b/after/ftplugin/c/textobj-function.vim
@@ -28,7 +28,7 @@ if !exists('*g:textobj_function_c_select')
   endfunction
 
   function! s:select_a()
-    if line('.') != '}'
+    if getline('.') != '}'
       normal ][
     endif
     let e = getpos('.')
@@ -44,7 +44,7 @@ if !exists('*g:textobj_function_c_select')
   endfunction
 
   function! s:select_i()
-    if line('.') != '}'
+    if getline('.') != '}'
       normal ][
     endif
     let e = getpos('.')


### PR DESCRIPTION
There was a small typo that was causing the next function to be selected
when the cursor was placed at the end of the function.  line() returns
the line number, not the contents.  Use getline() instead.
