### PR TITLE
Use normal! everywhere in C object

### DIFF
--- a/after/ftplugin/c/textobj-function.vim
+++ b/after/ftplugin/c/textobj-function.vim
@@ -29,10 +29,10 @@ if !exists('*g:textobj_function_c_select')
 
   function! s:select_a()
     if getline('.') != '}'
-      normal ][
+      normal! ][
     endif
     let e = getpos('.')
-    normal [[
+    normal! [[
     normal! k$%0k
     let b = getpos('.')
 
@@ -45,10 +45,10 @@ if !exists('*g:textobj_function_c_select')
 
   function! s:select_i()
     if getline('.') != '}'
-      normal ][
+      normal! ][
     endif
     let e = getpos('.')
-    normal [[
+    normal! [[
     let b = getpos('.')
 
     if 1 < e[1] - b[1]  " is there some code?


### PR DESCRIPTION
Some of the `normal` commands in the C textobj functions didn't use `!`
and thus would break if the user had remapped them. This patch fixes
that.
