### PR TITLE
Use % instead of [[ for finding the opening brace

### DIFF
--- a/after/ftplugin/c/textobj-function.vim
+++ b/after/ftplugin/c/textobj-function.vim
@@ -32,7 +32,7 @@ if !exists('*g:textobj_function_c_select')
       normal! ][
     endif
     let e = getpos('.')
-    normal! [[
+    normal! %
     normal! k$%0k
     let b = getpos('.')
 
@@ -48,7 +48,7 @@ if !exists('*g:textobj_function_c_select')
       normal! ][
     endif
     let e = getpos('.')
-    normal! [[
+    normal! %
     let b = getpos('.')
 
     if 1 < e[1] - b[1]  " is there some code?


### PR DESCRIPTION
[[ will only match opening braces that are located in the first column which makes af and if work incorrectly with other brace positioning styles. This commit switches to % instead which will always find the matching brace.

This seems to pass your current tests (it took some time to install the whole test toolchain successfully :D). I didn't want to write any new tests since I'm still not very familiar with the test toolchain.
