### PR TITLE
Add support for alternative brace style

### DIFF
--- a/after/ftplugin/c/textobj-function.vim
+++ b/after/ftplugin/c/textobj-function.vim
@@ -32,8 +32,9 @@ if !exists('*g:textobj_function_c_select')
       normal! ][
     endif
     let e = getpos('.')
-    normal! [[
-    normal! k$%0k
+    normal! %
+    call search(")", "bc")
+    normal! %0k
     let b = getpos('.')
 
     if 1 < e[1] - b[1]  " is there some code?
@@ -48,7 +49,7 @@ if !exists('*g:textobj_function_c_select')
       normal! ][
     endif
     let e = getpos('.')
-    normal! [[
+    normal! %
     let b = getpos('.')
 
     if 1 < e[1] - b[1]  " is there some code?

--- a/t/c.vim
+++ b/t/c.vim
@@ -29,6 +29,21 @@ function! s:paste_c_code()
   \   '  return 5;',
   \   '  return 6;',
   \   '}',
+  \   '',
+  \   'int OtherFoo(void) {',
+  \   '   return 7;',
+  \   '   return 8;',
+  \   '   return 9;',
+  \   '}',
+  \   '',
+  \   'int OtherFoo(',
+  \   '    int a,',
+  \   '    char b',
+  \   ') {',
+  \   '   return 7;',
+  \   '   return 8;',
+  \   '   return 9;',
+  \   '}'
   \ ]
   1 delete _
 endfunction
@@ -82,6 +97,22 @@ describe '<Plug>(textobj-function-a)'
     Expect line("'>") == 26
     Expect visualmode() ==# 'V'
   end
+
+  it 'works with alternative brace styles'
+    " With a one-line prototype
+    normal! 27G
+    execute 'normal' "vaf\<Esc>"
+    Expect line("'<") == 27
+    Expect line("'>") == 32
+    Expect visualmode() ==# 'V'
+
+    " With a more complex prototype
+    normal! 39G
+    execute 'normal' "vaf\<Esc>"
+    Expect line("'<") == 33
+    Expect line("'>") == 41
+    Expect visualmode() ==# 'V'
+  end
 end
 
 describe '<Plug>(textobj-function-i)'
@@ -131,6 +162,22 @@ describe '<Plug>(textobj-function-i)'
     execute 'normal' "vif\<Esc>"
     Expect line("'<") == 23
     Expect line("'>") == 25
+    Expect visualmode() ==# 'V'
+  end
+
+  it 'works with alternative brace styles'
+    " With a one-line prototype
+    normal! 28G
+    execute 'normal' "vif\<Esc>"
+    Expect line("'<") == 29
+    Expect line("'>") == 31
+    Expect visualmode() ==# 'V'
+
+    " With a more complex prototype
+    normal! 39G
+    execute 'normal' "vif\<Esc>"
+    Expect line("'<") == 38
+    Expect line("'>") == 40
     Expect visualmode() ==# 'V'
   end
 end


### PR DESCRIPTION
Currently, the plugin supports only C functions where the opening brace `{` is one line below the argument list's closing brace `)`, like the following:

```
void Foo(void) 
{
}
```

This pull request adds support for the "opening brace on the same line" style, i.e.:

```
void Foo(void) {
}
```
