### PR TITLE
c: Support for more code styles

### DIFF
--- a/autoload/textobj/function/c.vim
+++ b/autoload/textobj/function/c.vim
@@ -34,6 +34,9 @@ function! s:select_a()
   normal! %
   call search(')', 'bc')
   normal! %0k
+  if substitute(getline('.'), '^\s*$', '', '') == ''
+    normal! j
+  endif
   let b = getpos('.')
 
   if 1 < e[1] - b[1]  " is there some code?


### PR DESCRIPTION
I modified the c function parser to support coding styles that put the return value on the same line as the function name:

``` c
int main() {...
```

It is compatible with the old behavior of the plugin.
